### PR TITLE
Parse default arguments

### DIFF
--- a/tests/filecheck/arguments.py
+++ b/tests/filecheck/arguments.py
@@ -6,13 +6,13 @@ from torch.export import export
 from xdsl_torch.utils.import_program import import_program
 
 
-class Diag(torch.nn.Module):
+class DiagDef(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.diagonal(x)
 
 
 exported_program: torch.export.ExportedProgram = export(
-    Diag(), args=(torch.randn(10, 10),)
+    DiagDef(), args=(torch.randn(10, 10),)
 )
 
 # CHECK:        %int0 = arith.constant 0 : i32

--- a/tests/filecheck/arguments.py
+++ b/tests/filecheck/arguments.py
@@ -1,0 +1,22 @@
+# RUN: python %s | filecheck %s
+
+import torch
+from torch.export import export
+
+from xdsl_torch.utils.import_program import import_program
+
+
+class Diag(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.diagonal(x)
+
+
+exported_program: torch.export.ExportedProgram = export(
+    Diag(), args=(torch.randn(10, 10),)
+)
+
+# CHECK:        %int0 = arith.constant 0 : i32
+# CHECK-NEXT:   %int0_1 = arith.constant 0 : i32
+# CHECK-NEXT:   %int1 = arith.constant 1 : i32
+# CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int0, %int0_1, %int1 : tensor<10x10xf32>, i32, i32, i32 -> tensor<10xf32>
+print(import_program(exported_program))

--- a/tests/filecheck/arguments.py
+++ b/tests/filecheck/arguments.py
@@ -27,12 +27,28 @@ class Diag(torch.nn.Module):
         return torch.diagonal(x, 2, 1, 0)
 
 
-# CHECK:        %int2 = arith.constant 2 : i32
-# CHECK-NEXT:   %int1 = arith.constant 1 : i32
-# CHECK-NEXT:   %int0 = arith.constant 0 : i32
-# CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int2, %int1, %int0 : tensor<10x10xf32>, i32, i32, i32 -> tensor<8xf32>
 exported_program: torch.export.ExportedProgram = export(
     Diag(), args=(torch.randn(10, 10),)
 )
 
+# CHECK:        %int2 = arith.constant 2 : i32
+# CHECK-NEXT:   %int1 = arith.constant 1 : i32
+# CHECK-NEXT:   %int0 = arith.constant 0 : i32
+# CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int2, %int1, %int0 : tensor<10x10xf32>, i32, i32, i32 -> tensor<8xf32>
+print(import_program(exported_program))
+
+
+class Dist(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.pairwise_distance(x, y, 3, 1e-1, True)
+
+
+exported_program: torch.export.ExportedProgram = export(
+    Dist(), args=(torch.randn(10), torch.randn(10))
+)
+
+# CHECK:        %float3.0 = arith.constant 3.000000e+00 : f32
+# CHECK-NEXT:   %float0.1 = arith.constant 1.000000e-01 : f32
+# CHECK-NEXT:   %boolTrue = arith.constant True : i32
+# CHECK-NEXT:   %pairwise_distance = torch.aten.pairwise_distance %x, %y, %float3.0, %float0.1, %boolTrue : tensor<10xf32>, tensor<10xf32>, f32, f32, i32 -> tensor<1xf32>
 print(import_program(exported_program))

--- a/tests/filecheck/arguments.py
+++ b/tests/filecheck/arguments.py
@@ -20,3 +20,19 @@ exported_program: torch.export.ExportedProgram = export(
 # CHECK-NEXT:   %int1 = arith.constant 1 : i32
 # CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int0, %int0_1, %int1 : tensor<10x10xf32>, i32, i32, i32 -> tensor<10xf32>
 print(import_program(exported_program))
+
+
+class Diag(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.diagonal(x, 2, 1, 0)
+
+
+# CHECK:        %int2 = arith.constant 2 : i32
+# CHECK-NEXT:   %int1 = arith.constant 1 : i32
+# CHECK-NEXT:   %int0 = arith.constant 0 : i32
+# CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int2, %int1, %int0 : tensor<10x10xf32>, i32, i32, i32 -> tensor<8xf32>
+exported_program: torch.export.ExportedProgram = export(
+    Diag(), args=(torch.randn(10, 10),)
+)
+
+print(import_program(exported_program))

--- a/tests/filecheck/arguments.py
+++ b/tests/filecheck/arguments.py
@@ -49,6 +49,6 @@ exported_program: torch.export.ExportedProgram = export(
 
 # CHECK:        %float3.0 = arith.constant 3.000000e+00 : f32
 # CHECK-NEXT:   %float0.1 = arith.constant 1.000000e-01 : f32
-# CHECK-NEXT:   %boolTrue = arith.constant True : i32
-# CHECK-NEXT:   %pairwise_distance = torch.aten.pairwise_distance %x, %y, %float3.0, %float0.1, %boolTrue : tensor<10xf32>, tensor<10xf32>, f32, f32, i32 -> tensor<1xf32>
+# CHECK-NEXT:   %boolTrue = arith.constant true
+# CHECK-NEXT:   %pairwise_distance = torch.aten.pairwise_distance %x, %y, %float3.0, %float0.1, %boolTrue : tensor<10xf32>, tensor<10xf32>, f32, f32, i1 -> tensor<1xf32>
 print(import_program(exported_program))

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,8 @@
+import pytest
+
+from xdsl_torch.utils.import_program import create_constant_op_with_value
+
+
+def test_import_bad_value():
+    with pytest.raises(NotImplementedError):
+        create_constant_op_with_value("string")

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -79,7 +79,7 @@ def import_program(
         tensor_meta = all_producer_nodes[arg.arg.name].meta["tensor_meta"]
         return TensorType(
             TORCH_DTYPE_TO_XDSL_TYPE[tensor_meta.dtype],
-            tensor_meta.shape,  # type: ignore
+            tensor_meta.shape,
         )
 
     inp_sign = list(map(make_tensor_type, prog.graph_signature.input_specs))
@@ -105,7 +105,7 @@ def import_program(
                     operands=operands,
                     result_types=[
                         TensorType(
-                            TORCH_DTYPE_TO_XDSL_TYPE[node.meta["tensor_meta"].dtype],  # type: ignore
+                            TORCH_DTYPE_TO_XDSL_TYPE[node.meta["tensor_meta"].dtype],
                             node.meta["tensor_meta"].shape,
                         )
                     ],  # we currently think that everything returns a single tensor

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -17,12 +17,12 @@ def create_constant_op_with_value(value: Any) -> tuple[str, arith.ConstantOp]:
     Construct a ConstantOp for a scalar value.
     """
     match value:
+        case bool():
+            attr = BoolAttr.from_bool(value)
         case int():
             attr = IntegerAttr.from_int_and_width(value, 32)
         case float():
             attr = FloatAttr(value, 32)
-        case bool():
-            attr = BoolAttr.from_bool(value)
         case _:
             raise NotImplementedError(
                 f"Default values not implemented for type {type(value)}"

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -28,7 +28,7 @@ def create_constant_op_with_value(value: Any) -> tuple[str, arith.ConstantOp]:
                 f"Default values not implemented for type {type(value)}"
             )
 
-    new_const = arith.ConstantOp(attr, attr.get_type())
+    new_const = arith.ConstantOp(attr)
     new_name = f"{type(value).__name__}{value}"
     new_const.result.name_hint = new_name
 

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -52,15 +52,20 @@ def get_op_operands(
                 arg_value.name in xdsl_nodes
             ), f"Node {arg_value.name} should have been processed before"
             operands.append(xdsl_nodes[arg_value.name])
+            continue
 
         if arg_value is None:
             assert (
                 arg_spec.has_default_value()
             ), "A non provided argument must have a default value"
             assert arg_spec.default_value is not None, "Inconsistency inside a spec"
-            new_name, new_const = literal_to_ssa(arg_spec.default_value)
-            xdsl_nodes[new_name] = new_const
-            operands.append(new_const)
+            value = arg_spec.default_value
+        else:
+            value = arg_value
+
+        new_name, new_const = literal_to_ssa(value)
+        xdsl_nodes[new_name] = new_const
+        operands.append(new_const)
 
     return operands
 

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -1,11 +1,62 @@
+from itertools import zip_longest
+from typing import Any
+
 import torch
 from xdsl.builder import ImplicitBuilder
-from xdsl.dialects import func
-from xdsl.dialects.builtin import TensorType
+from xdsl.dialects import arith, func
+from xdsl.dialects.builtin import BoolAttr, FloatAttr, IntegerAttr, TensorType
 from xdsl.ir import SSAValue
 
 from xdsl_torch.dialects.torch_mapping import XDSL_TORCH_OPS
 from xdsl_torch.utils.type_mapping import TORCH_DTYPE_TO_XDSL_TYPE
+
+
+def literal_to_ssa(value: Any) -> tuple[str, SSAValue]:
+    match value:
+        case int():
+            attr = IntegerAttr.from_int_and_width(value, 32)
+        case float():
+            attr = FloatAttr(value, 32)
+        case bool():
+            attr = BoolAttr.from_bool(value)
+        case _:
+            raise NotImplementedError(
+                f"Default values not implemented for type {type(value)}"
+            )
+
+    new_const = arith.ConstantOp(attr, attr.get_type())
+    new_name = f"{type(value).__name__}{value}"
+    new_const.result.name_hint = new_name
+
+    return new_name, new_const.result
+
+
+def get_op_operands(
+    node: torch.fx.Node, xdsl_nodes: dict[str, SSAValue]
+) -> list[SSAValue]:
+    arguments: list[tuple[torch.Argument, Any]] = list(
+        zip_longest(node.target._schema.arguments, node.args)  # type: ignore
+    )
+    operands: list[SSAValue] = []
+
+    for arg_spec, arg_value in arguments:
+        if type(arg_value) is torch.fx.Node:
+            if arg_value.name not in xdsl_nodes:
+                raise Exception(
+                    f"Node {arg_value.name} should have been processed before"
+                )
+            operands.append(xdsl_nodes[arg_value.name])
+
+        if arg_value is None:
+            if not (
+                arg_spec.has_default_value() and arg_spec.default_value is not None
+            ):
+                raise Exception("A non provided argument must have a default value")
+            new_name, new_const = literal_to_ssa(arg_spec.default_value)
+            xdsl_nodes[new_name] = new_const
+            operands.append(new_const)
+
+    return operands
 
 
 def import_program(
@@ -27,7 +78,8 @@ def import_program(
     ):
         tensor_meta = all_producer_nodes[arg.arg.name].meta["tensor_meta"]
         return TensorType(
-            TORCH_DTYPE_TO_XDSL_TYPE[tensor_meta.dtype], tensor_meta.shape
+            TORCH_DTYPE_TO_XDSL_TYPE[tensor_meta.dtype],
+            tensor_meta.shape,  # type: ignore
         )
 
     inp_sign = list(map(make_tensor_type, prog.graph_signature.input_specs))
@@ -48,15 +100,12 @@ def import_program(
                     raise NotImplementedError(
                         f"Unimplemented: target={node.target}, {node.meta}"
                     )
-                arg_names = [
-                    arg.name if type(arg) is torch.fx.Node else "" for arg in node.args
-                ]
-                assert all(arg_names)
+                operands = get_op_operands(node, xdsl_nodes)
                 new_op = XDSL_TORCH_OPS[node.target](
-                    operands=[xdsl_nodes[name] for name in arg_names],
+                    operands=operands,
                     result_types=[
                         TensorType(
-                            TORCH_DTYPE_TO_XDSL_TYPE[node.meta["tensor_meta"].dtype],
+                            TORCH_DTYPE_TO_XDSL_TYPE[node.meta["tensor_meta"].dtype],  # type: ignore
                             node.meta["tensor_meta"].shape,
                         )
                     ],  # we currently think that everything returns a single tensor

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -35,7 +35,7 @@ def create_constant_op_with_value(value: Any) -> tuple[str, arith.ConstantOp]:
     return new_name, new_const
 
 
-def get_op_operands(
+def create_op_operands(
     node: torch.fx.Node, xdsl_nodes: dict[str, SSAValue], builder: Builder
 ) -> list[SSAValue]:
     """
@@ -113,7 +113,7 @@ def import_program(
                 raise NotImplementedError(
                     f"Unimplemented: target={node.target}, {node.meta}"
                 )
-            operands = get_op_operands(node, xdsl_nodes, builder)
+            operands = create_op_operands(node, xdsl_nodes, builder)
             new_op = XDSL_TORCH_OPS[node.target](
                 operands=operands,
                 result_types=[

--- a/xdsl_torch/utils/type_mapping.py
+++ b/xdsl_torch/utils/type_mapping.py
@@ -1,4 +1,11 @@
 import torch
-from xdsl.dialects.builtin import f16, f32, f64
+from xdsl.dialects.builtin import f16, f32, f64, i16, i32, i64
 
-TORCH_DTYPE_TO_XDSL_TYPE = {torch.float16: f16, torch.float32: f32, torch.float64: f64}
+TORCH_DTYPE_TO_XDSL_TYPE = {
+    torch.float16: f16,
+    torch.float32: f32,
+    torch.float64: f64,
+    torch.int16: i16,
+    torch.int32: i32,
+    torch.int64: i64,
+}


### PR DESCRIPTION
This is the first step of making argument parsing correct. 
We also need to support:
* Literal arguments (`f(a=1)`)
* `None` arguments

Afterwards, we need to fix the export process from mlir to exported program. There shouldn't be a big change there, but I want to finish the argument parsing first. 