### PR TITLE
Support ops with multiple return values

### DIFF
--- a/tests/filecheck/outputs.py
+++ b/tests/filecheck/outputs.py
@@ -1,0 +1,24 @@
+# RUN: python %s | filecheck %s
+
+import torch
+from torch.export import export
+
+from xdsl_torch.utils.import_program import import_program
+
+
+class MaxPool(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.nn.functional.max_pool2d_with_indices(x, 1, 1)  # type: ignore
+
+
+exported_program: torch.export.ExportedProgram = export(
+    MaxPool(), args=(torch.randn(1, 100, 100),)
+)
+
+print(exported_program.graph)
+
+# CHECK:        %int0 = arith.constant 0 : i32
+# CHECK-NEXT:   %int0_1 = arith.constant 0 : i32
+# CHECK-NEXT:   %int1 = arith.constant 1 : i32
+# CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int0, %int0_1, %int1 : tensor<10x10xf32>, i32, i32, i32 -> tensor<10xf32>
+print(import_program(exported_program))

--- a/tests/filecheck/outputs.py
+++ b/tests/filecheck/outputs.py
@@ -15,10 +15,6 @@ exported_program: torch.export.ExportedProgram = export(
     MaxPool(), args=(torch.randn(1, 100, 100),)
 )
 
-print(exported_program.graph)
-
-# CHECK:        %int0 = arith.constant 0 : i32
-# CHECK-NEXT:   %int0_1 = arith.constant 0 : i32
-# CHECK-NEXT:   %int1 = arith.constant 1 : i32
-# CHECK-NEXT:   %diagonal = torch.aten.diagonal %x, %int0, %int0_1, %int1 : tensor<10x10xf32>, i32, i32, i32 -> tensor<10xf32>
+# CHECK:       %4, %5 = torch.aten.max_pool2d_with_indices %x, %0, %1, %2, %3, %boolFalse : tensor<1x100x100xf32>, vector<2xi32>, vector<2xi32>, vector<2xi32>, vector<2xi32>, i1 -> tensor<1x100x100xf32>, tensor<1x100x100xi64>
+# CHECK-NEXT:  func.return %4, %5 : tensor<1x100x100xf32>, tensor<1x100x100xi64>
 print(import_program(exported_program))

--- a/tests/filecheck/outputs.py
+++ b/tests/filecheck/outputs.py
@@ -15,6 +15,6 @@ exported_program: torch.export.ExportedProgram = export(
     MaxPool(), args=(torch.randn(1, 100, 100),)
 )
 
-# CHECK:       %4, %5 = torch.aten.max_pool2d_with_indices %x, %0, %1, %2, %3, %boolFalse : tensor<1x100x100xf32>, vector<2xi32>, vector<2xi32>, vector<2xi32>, vector<2xi32>, i1 -> tensor<1x100x100xf32>, tensor<1x100x100xi64>
-# CHECK-NEXT:  func.return %4, %5 : tensor<1x100x100xf32>, tensor<1x100x100xi64>
+# CHECK:       %{{\S+}}, %{{\S+}} = torch.aten.max_pool2d_with_indices %x, %{{\S+}}, %{{\S+}}, %{{\S+}}, %{{\S+}}, %boolFalse : tensor<1x100x100xf32>, vector<2xi32>, vector<2xi32>, vector<2xi32>, vector<2xi32>, i1 -> tensor<1x100x100xf32>, tensor<1x100x100xi64>
+# CHECK-NEXT:  func.return %{{\S+}}, %{{\S+}} : tensor<1x100x100xf32>, tensor<1x100x100xi64>
 print(import_program(exported_program))

--- a/xdsl_torch/utils/import_program.py
+++ b/xdsl_torch/utils/import_program.py
@@ -180,7 +180,6 @@ def import_torch_op_overload(
         operands=operands,
         result_types=result_types,
     )
-    print(new_op.results)
     builder.insert(new_op)
     xdsl_nodes[node.name] = new_op.results
 
@@ -196,7 +195,7 @@ def import_getitem(node: torch.fx.Node, xdsl_nodes: dict[str, tuple[SSAValue, ..
     assert isinstance(index, int), f"Unexpected getitem arguments: {node.args}"
 
     if len(xdsl_nodes[ref_node.name]) > 1:
-        xdsl_nodes[node.name] = tuple([xdsl_nodes[ref_node.name][index]])
+        xdsl_nodes[node.name] = (xdsl_nodes[ref_node.name][index],)
     else:
         raise NotImplementedError(
             "getitem is currently only supported for multi output ops"
@@ -233,7 +232,7 @@ def import_program(
     xdsl_nodes: dict[str, tuple[SSAValue, ...]] = {}
     for i, original_arg in enumerate(prog.graph_signature.input_specs):
         func_op.args[i].name_hint = original_arg.arg.name
-        xdsl_nodes[original_arg.arg.name] = tuple([func_op.args[i]])
+        xdsl_nodes[original_arg.arg.name] = (func_op.args[i],)
 
     for node in prog.graph.nodes:
         if node.op == "call_function":


### PR DESCRIPTION
Now ops which return multiple values are parsed correctly. Also refactored type inference code. 